### PR TITLE
add empty default configuration for withMedia()

### DIFF
--- a/src/AddonServiceProvider.php
+++ b/src/AddonServiceProvider.php
@@ -35,7 +35,7 @@ class AddonServiceProvider extends ServiceProvider
 
         // register media upload macros on crud fields and columns.
         if (! CrudField::hasMacro('withMedia')) {
-            CrudField::macro('withMedia', function ($uploadDefinition, $subfield = null, $registerEvents = true) {
+            CrudField::macro('withMedia', function ($uploadDefinition = [], $subfield = null, $registerEvents = true) {
                 $uploadDefinition = is_array($uploadDefinition) ? $uploadDefinition : [];
                 /** @var CrudField $this */
                 RegisterUploadEvents::handle($this, $uploadDefinition, 'withMedia', $subfield, $registerEvents);
@@ -45,7 +45,7 @@ class AddonServiceProvider extends ServiceProvider
         }
 
         if (! CrudColumn::hasMacro('withMedia')) {
-            CrudColumn::macro('withMedia', function ($uploadDefinition, $subfield = null, $registerEvents = true) {
+            CrudColumn::macro('withMedia', function ($uploadDefinition = [], $subfield = null, $registerEvents = true) {
                 $uploadDefinition = is_array($uploadDefinition) ? $uploadDefinition : [];
                 /** @var CrudColumn $this */
                 RegisterUploadEvents::handle($this, $uploadDefinition, 'withMedia', $subfield, $registerEvents);


### PR DESCRIPTION
This adds default empty to `withMedia` so that you can do `withMedia()` without any argument. 