### PR TITLE
Pass $entry to `whenSaving` Closure

### DIFF
--- a/src/Uploaders/MediaUploader.php
+++ b/src/Uploaders/MediaUploader.php
@@ -161,7 +161,7 @@ abstract class MediaUploader extends Uploader
         $constrainedMedia->setMediaUploader($this);
 
         if ($this->savingEventCallback && is_callable($this->savingEventCallback)) {
-            $constrainedMedia = call_user_func_array($this->savingEventCallback, [$constrainedMedia, $this,$entry]);
+            $constrainedMedia = call_user_func_array($this->savingEventCallback, [$constrainedMedia, $this, $entry]);
         }
 
         if (! $constrainedMedia) {

--- a/src/Uploaders/MediaUploader.php
+++ b/src/Uploaders/MediaUploader.php
@@ -90,11 +90,11 @@ abstract class MediaUploader extends Uploader
             if (! is_array($values)) {
                 $values = json_decode($values, true);
             }
-            
+
             $repeatableUploaders = array_merge(app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()), [$this]);
             foreach ($repeatableUploaders as $uploader) {
                 $uploadValues = $uploader->getPreviousRepeatableValues($entry);
-                
+
                 $values = $this->mergeValuesRecursive($values, $uploadValues);
             }
 
@@ -161,7 +161,7 @@ abstract class MediaUploader extends Uploader
         $constrainedMedia->setMediaUploader($this);
 
         if ($this->savingEventCallback && is_callable($this->savingEventCallback)) {
-            $constrainedMedia = call_user_func_array($this->savingEventCallback, [$constrainedMedia, $this]);
+            $constrainedMedia = call_user_func_array($this->savingEventCallback, [$constrainedMedia, $this,$entry]);
         }
 
         if (! $constrainedMedia) {
@@ -209,7 +209,7 @@ abstract class MediaUploader extends Uploader
         });
         $previousMedia->each(function($item) use (&$orderedMedia) {
             $orderedMedia[] = $item[$this->getName()];
-        }); 
+        });
 
         return $orderedMedia;
     }
@@ -236,7 +236,7 @@ abstract class MediaUploader extends Uploader
         if (get_class($file) === File::class) {
             return $entry->addMedia($file->getPathName());
         }
-        
+
     }
 
     private function getConversionToDisplay($item)


### PR DESCRIPTION
A user [requested](https://github.com/Laravel-Backpack/medialibrary-uploaders/issues/32) this feature so Devs can use `$entry` inside `whenSaving` closure to name files more logically.

For example, `$entry->slug` as file name:
```php
CRUD::field('main_image')
->label('Main Image')
->type('image')
->withMedia([
  'whenSaving' => function($spatieMedia, $backpackMediaObject, $entry) {
    return $spatieMedia->usingFileName($entry->slug.'.jpg')->withResponsiveImages();
  }
]);
```
