### PR TITLE
fix: correct media collection filtering and disk assignment logic

### DIFF
--- a/src/Uploaders/MediaUploader.php
+++ b/src/Uploaders/MediaUploader.php
@@ -34,15 +34,14 @@ abstract class MediaUploader extends Uploader
         $this->displayConversions = $configuration['displayConversions'] ?? [];
         $this->displayConversions = (array) $this->displayConversions;
 
-        $modelDefinition = $this->getModelInstance($crudObject)->getRegisteredMediaCollections()
-                            ->reject(function ($item) {
-                                $item->name !== $this->collection;
-                            })
-                            ->first();
+        $modelDefinition = $this->getModelInstance($crudObject)
+            ->getRegisteredMediaCollections()
+            ->reject(fn($item) => $item->name !== $this->collection)
+            ->first();
 
-        $configuration['disk'] = $modelDefinition?->diskName ?? null;
-
-        $configuration['disk'] = empty($configuration['disk']) ? $crudObject['disk'] ?? config('media-library.disk_name') : null;
+        $configuration['disk'] = $modelDefinition?->diskName
+            ?? $crudObject['disk']
+            ?? config('media-library.disk_name');
 
         // read https://spatie.be/docs/laravel-medialibrary/v10/advanced-usage/using-a-custom-directory-structure#main
         // on how to customize file directory


### PR DESCRIPTION
This PR resolves logical issues in media collection filtering and disk assignment during uploader initialization.

**1. Incorrect filtering of media collections**
The reject() callback did not return a value, causing all media collections to be excluded instead of matching by name.

**2. Disk assignment bug**
The resolved disk name from the media collection definition was being overwritten by null due to incorrect conditional logic.

Solution
- Added a return statement to the reject() callback to properly filter media collections by $this->collection.
- Refactored disk resolution logic to avoid overwriting with null.