### PR TITLE
Media Conversion fix

### DIFF
--- a/src/Uploaders/MediaUploader.php
+++ b/src/Uploaders/MediaUploader.php
@@ -266,6 +266,10 @@ abstract class MediaUploader extends Uploader
     {
         $path = PathGeneratorFactory::create($media);
 
+        if ($entry) {
+            $entry->registerMediaConversions();
+        }
+
         if ($entry && ! empty($entry->mediaConversions)) {
             $conversion = array_values(array_filter($entry->mediaConversions, function ($item) use ($media) {
                 return $item->getName() === $this->getConversionToDisplay($media);


### PR DESCRIPTION
Added a call to registerMediaConversions() prior to checking for media conversions on $entry. Without this call a dropzone field displaying a converted image will end up deleting the image on update.